### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/fixtures/paper/paper.html
+++ b/fixtures/paper/paper.html
@@ -3,7 +3,7 @@
 <p>figshare. 2016. “Figshare - Credit for All Your Research.” <a href="https://figshare.com" class="uri">https://figshare.com</a>.</p>
 </div>
 <div id="ref-figshare_archive">
-<p>figshare Archive. n.d. “Fidgit: An Ungodly Union of GitHub and Figshare.” <a href="http://dx.doi.org/10.6084/m9.figshare.828487" class="uri">http://dx.doi.org/10.6084/m9.figshare.828487</a>. doi:<a href="https://doi.org/10.6084/m9.figshare.828487">10.6084/m9.figshare.828487</a>.</p>
+<p>figshare Archive. n.d. “Fidgit: An Ungodly Union of GitHub and Figshare.” <a href="https://doi.org/10.6084/m9.figshare.828487" class="uri">https://doi.org/10.6084/m9.figshare.828487</a>. doi:<a href="https://doi.org/10.6084/m9.figshare.828487">10.6084/m9.figshare.828487</a>.</p>
 </div>
 <div id="ref-GitHub">
 <p>GitHub. 2008. “GitHub.com.” <a href="https://github.com" class="uri">https://github.com</a>.</p>

--- a/fixtures/paper/paper.md
+++ b/fixtures/paper/paper.md
@@ -22,6 +22,6 @@ bibliography: paper.bib
 
 # Summary
 
-This is a proof of concept integration between a GitHub [@GitHub] repo and figshare [@figshare] in an effort to get a DOI for a GitHub repository. When a repository is tagged for release on GitHub, Fidgit [@Fidgit] will import the release into figshare thus giving the code bundle a DOI. In a somewhat meta fashion, Fidgit is publishing itself to figshare with DOI 'http://dx.doi.org/10.6084/m9.figshare.828487' [@figshare_archive].
+This is a proof of concept integration between a GitHub [@GitHub] repo and figshare [@figshare] in an effort to get a DOI for a GitHub repository. When a repository is tagged for release on GitHub, Fidgit [@Fidgit] will import the release into figshare thus giving the code bundle a DOI. In a somewhat meta fashion, Fidgit is publishing itself to figshare with DOI 'https://doi.org/10.6084/m9.figshare.828487' [@figshare_archive].
 
 # References

--- a/fixtures/paper/paper.xml
+++ b/fixtures/paper/paper.xml
@@ -22,7 +22,7 @@
   </articleinfo>
   <body>
     <h1 id="summary">Summary</h1>
-    <p>This is a proof of concept integration between a GitHub <span class="citation">[@GitHub]</span> repo and figshare <span class="citation">[@figshare]</span> in an effort to get a DOI for a GitHub repository. When a repository is tagged for release on GitHub, Fidgit <span class="citation">[@Fidgit]</span> will import the release into figshare thus giving the code bundle a DOI. In a somewhat meta fashion, Fidgit is publishing itself to figshare with DOI 'http://dx.doi.org/10.6084/m9.figshare.828487' <span class="citation">[@figshare_archive]</span>.</p>
+    <p>This is a proof of concept integration between a GitHub <span class="citation">[@GitHub]</span> repo and figshare <span class="citation">[@figshare]</span> in an effort to get a DOI for a GitHub repository. When a repository is tagged for release on GitHub, Fidgit <span class="citation">[@Fidgit]</span> will import the release into figshare thus giving the code bundle a DOI. In a somewhat meta fashion, Fidgit is publishing itself to figshare with DOI 'https://doi.org/10.6084/m9.figshare.828487' <span class="citation">[@figshare_archive]</span>.</p>
     <h1 id="references">References</h1>
   </body>
 </article>

--- a/fixtures/review_body.txt
+++ b/fixtures/review_body.txt
@@ -1,7 +1,7 @@
 **Submitting author:** @zhaozhang (<a href="http://orcid.org/0000-0001-5921-0035">Zhao Zhang</a>)
 **Repository:** <a href="https://github.com/applicationskeleton/Skeleton" target ="_blank">https://github.com/applicationskeleton/Skeleton</a>
 **Version:** v1.2
-**Archive:** <a href="http://dx.doi.org/10.5281/zenodo.13750" target ="_blank">http://dx.doi.org/10.5281/zenodo.13750</a>
+**Archive:** <a href="https://doi.org/10.5281/zenodo.13750" target ="_blank">https://doi.org/10.5281/zenodo.13750</a>
 
 ## Status
 
@@ -21,7 +21,7 @@ Markdown: [![status](http://joss.theoj.org/papers/6b34fdbf8215c1ecd4941afc8be7a7
 - [x] **Repository:** Is the source code for this software available at the <a target="_blank" href="https://github.com/applicationskeleton/Skeleton">repository url</a>?
 - [x] **License:** Does the repository contain a plain-text LICENSE file with the contents of an [OSI approved](https://opensource.org/licenses/alphabetical) software license?
 - [x] **Version:** Does the release version given match the GitHub release (v1.2)?
-- [x] **Archive:** Does the <a target="_blank" href="http://dx.doi.org/10.5281/zenodo.13750">software archive</a> resolve?
+- [x] **Archive:** Does the <a target="_blank" href="https://doi.org/10.5281/zenodo.13750">software archive</a> resolve?
 
 ### Functionality
 

--- a/fixtures/vcr_cassettes/review.yml
+++ b/fixtures/vcr_cassettes/review.yml
@@ -80,8 +80,8 @@ http_interactions:
         author:** @zhaozhang (<a href=\"http://orcid.org/0000-0001-5921-0035\">Zhao
         Zhang</a>)\r\n**Repository:** <a href=\"https://github.com/applicationskeleton/Skeleton\"
         target =\"_blank\">https://github.com/applicationskeleton/Skeleton</a>\r\n**Version:**
-        v1.2\r\n**Archive:** <a href=\"http://dx.doi.org/10.5281/zenodo.13750\" target
-        =\"_blank\">http://dx.doi.org/10.5281/zenodo.13750</a>\r\n\r\n## Status\r\n\r\n[![status](http://joss.theoj.org/papers/6b34fdbf8215c1ecd4941afc8be7a7e6/status.svg)](http://joss.theoj.org/papers/6b34fdbf8215c1ecd4941afc8be7a7e6)\r\n\r\nStatus
+        v1.2\r\n**Archive:** <a href=\"https://doi.org/10.5281/zenodo.13750\" target
+        =\"_blank\">https://doi.org/10.5281/zenodo.13750</a>\r\n\r\n## Status\r\n\r\n[![status](http://joss.theoj.org/papers/6b34fdbf8215c1ecd4941afc8be7a7e6/status.svg)](http://joss.theoj.org/papers/6b34fdbf8215c1ecd4941afc8be7a7e6)\r\n\r\nStatus
         badge code:\r\n\r\n```\r\nHTML: <a href=\"http://joss.theoj.org/papers/6b34fdbf8215c1ecd4941afc8be7a7e6\"><img
         src=\"http://joss.theoj.org/papers/6b34fdbf8215c1ecd4941afc8be7a7e6/status.svg\"></a>\r\nMarkdown:
         [![status](http://joss.theoj.org/papers/6b34fdbf8215c1ecd4941afc8be7a7e6/status.svg)]http://joss.theoj.org/papers/6b34fdbf8215c1ecd4941afc8be7a7e6\r\n```\r\n\r\n##
@@ -92,7 +92,7 @@ http_interactions:
         the contents of an [OSI approved](https://opensource.org/licenses/alphabetical)
         software license?\r\n- [x] **Version:** Does the release version given match
         the GitHub release (v1.2)?\r\n- [x] **Archive:** Does the <a target=\"_blank\"
-        href=\"http://dx.doi.org/10.5281/zenodo.13750\">software archive</a> resolve?\r\n\r\n###
+        href=\"https://doi.org/10.5281/zenodo.13750\">software archive</a> resolve?\r\n\r\n###
         Functionality\r\n\r\n- [x] **Installation:** Does installation proceed as
         outlined in the documentation?\r\n- [x] **Functionality:** Have the functional
         claims of the software been confirmed?\r\n- [x] **Performance:** Have the
@@ -197,8 +197,8 @@ http_interactions:
         author:** @zhaozhang (<a href=\"http://orcid.org/0000-0001-5921-0035\">Zhao
         Zhang</a>)\r\n**Repository:** <a href=\"https://github.com/applicationskeleton/Skeleton\"
         target =\"_blank\">https://github.com/applicationskeleton/Skeleton</a>\r\n**Version:**
-        v1.2\r\n**Archive:** <a href=\"http://dx.doi.org/10.5281/zenodo.13750\" target
-        =\"_blank\">http://dx.doi.org/10.5281/zenodo.13750</a>\r\n\r\n## Status\r\n\r\n[![status](http://joss.theoj.org/papers/6b34fdbf8215c1ecd4941afc8be7a7e6/status.svg)](http://joss.theoj.org/papers/6b34fdbf8215c1ecd4941afc8be7a7e6)\r\n\r\nStatus
+        v1.2\r\n**Archive:** <a href=\"https://doi.org/10.5281/zenodo.13750\" target
+        =\"_blank\">https://doi.org/10.5281/zenodo.13750</a>\r\n\r\n## Status\r\n\r\n[![status](http://joss.theoj.org/papers/6b34fdbf8215c1ecd4941afc8be7a7e6/status.svg)](http://joss.theoj.org/papers/6b34fdbf8215c1ecd4941afc8be7a7e6)\r\n\r\nStatus
         badge code:\r\n\r\n```\r\nHTML: <a href=\"http://joss.theoj.org/papers/6b34fdbf8215c1ecd4941afc8be7a7e6\"><img
         src=\"http://joss.theoj.org/papers/6b34fdbf8215c1ecd4941afc8be7a7e6/status.svg\"></a>\r\nMarkdown:
         [![status](http://joss.theoj.org/papers/6b34fdbf8215c1ecd4941afc8be7a7e6/status.svg)]http://joss.theoj.org/papers/6b34fdbf8215c1ecd4941afc8be7a7e6\r\n```\r\n\r\n##
@@ -209,7 +209,7 @@ http_interactions:
         the contents of an [OSI approved](https://opensource.org/licenses/alphabetical)
         software license?\r\n- [x] **Version:** Does the release version given match
         the GitHub release (v1.2)?\r\n- [x] **Archive:** Does the <a target=\"_blank\"
-        href=\"http://dx.doi.org/10.5281/zenodo.13750\">software archive</a> resolve?\r\n\r\n###
+        href=\"https://doi.org/10.5281/zenodo.13750\">software archive</a> resolve?\r\n\r\n###
         Functionality\r\n\r\n- [x] **Installation:** Does installation proceed as
         outlined in the documentation?\r\n- [x] **Functionality:** Have the functional
         claims of the software been confirmed?\r\n- [x] **Performance:** Have the

--- a/fixtures/vcr_cassettes/reviews.yml
+++ b/fixtures/vcr_cassettes/reviews.yml
@@ -77,8 +77,8 @@ http_interactions:
         author:** @meyera (<a href=\"http://orcid.org/0000-0002-6944-2478\">Alexander
         Meyer</a>)\r\n**Repository:** <a href=\"https://github.com/meyera/riskscorer\"
         target =\"_blank\">https://github.com/meyera/riskscorer</a>\r\n**Version:**
-        v0.2.0\r\n**Archive:** <a href=\"http://dx.doi.org/10.5281/zenodo.51342\"
-        target =\"_blank\">http://dx.doi.org/10.5281/zenodo.51342</a>\r\n\r\n## Status\r\n\r\n[![status](http://joss.theoj.org/papers/b6fca2486948af8ebd56fc31fc7277c3/status.svg)](http://joss.theoj.org/papers/b6fca2486948af8ebd56fc31fc7277c3)\r\n\r\nStatus
+        v0.2.0\r\n**Archive:** <a href=\"https://doi.org/10.5281/zenodo.51342\"
+        target =\"_blank\">https://doi.org/10.5281/zenodo.51342</a>\r\n\r\n## Status\r\n\r\n[![status](http://joss.theoj.org/papers/b6fca2486948af8ebd56fc31fc7277c3/status.svg)](http://joss.theoj.org/papers/b6fca2486948af8ebd56fc31fc7277c3)\r\n\r\nStatus
         badge code:\r\n\r\n```\r\nHTML: <a href=\"http://joss.theoj.org/papers/b6fca2486948af8ebd56fc31fc7277c3\"><img
         src=\"http://joss.theoj.org/papers/b6fca2486948af8ebd56fc31fc7277c3/status.svg\"></a>\r\nMarkdown:
         [![status](http://joss.theoj.org/papers/b6fca2486948af8ebd56fc31fc7277c3/status.svg)](http://joss.theoj.org/papers/b6fca2486948af8ebd56fc31fc7277c3)\r\n```\r\n\r\n##
@@ -89,7 +89,7 @@ http_interactions:
         contents of an [OSI approved](https://opensource.org/licenses/alphabetical)
         software license?\r\n- [ ] **Version:** Does the release version given match
         the GitHub release (v0.2.0)?\r\n- [ ] **Archive:** Does the <a target=\"_blank\"
-        href=\"http://dx.doi.org/10.5281/zenodo.51342\">software archive</a> resolve?\r\n\r\n###
+        href=\"https://doi.org/10.5281/zenodo.51342\">software archive</a> resolve?\r\n\r\n###
         Functionality\r\n\r\n- [ ] **Installation:** Does installation proceed as
         outlined in the documentation?\r\n- [ ] **Functionality:** Have the functional
         claims of the software been confirmed?\r\n- [ ] **Performance:** Have the
@@ -116,7 +116,7 @@ http_interactions:
         author:** @genomematt (<a href=\"http://orcid.org/0000-0001-6624-4698\">Matthew
         J Wakefield</a>)\r\n**Repository:** <a href=\"http://github.com/genomematt/xenomapper/\"
         target =\"_blank\">http://github.com/genomematt/xenomapper/</a>\r\n**Version:**
-        v1.0.0\r\n**Archive:** <a href=\"http://dx.doi.org/10.5281/zenodo.51337\"
+        v1.0.0\r\n**Archive:** <a href=\"https://doi.org/10.5281/zenodo.51337\"
         target =\"_blank\">10.5281/zenodo.51337</a>\r\n\r\n## Status\r\n\r\n[![status](http://joss.theoj.org/papers/7065e20e97ff4e44695b5e9fef7cdcd8/status.svg)](http://joss.theoj.org/papers/7065e20e97ff4e44695b5e9fef7cdcd8)\r\n\r\nStatus
         badge code:\r\n\r\n```\r\nHTML: <a href=\"http://joss.theoj.org/papers/7065e20e97ff4e44695b5e9fef7cdcd8\"><img
         src=\"http://joss.theoj.org/papers/7065e20e97ff4e44695b5e9fef7cdcd8/status.svg\"></a>\r\nMarkdown:
@@ -128,7 +128,7 @@ http_interactions:
         the contents of an [OSI approved](https://opensource.org/licenses/alphabetical)
         software license?\r\n- [ ] **Version:** Does the release version given match
         the GitHub release (v1.0.0)?\r\n- [ ] **Archive:** Does the <a target=\"_blank\"
-        href=\"http://dx.doi.org/10.5281/zenodo.51337\">software archive</a> resolve?\r\n\r\n###
+        href=\"https://doi.org/10.5281/zenodo.51337\">software archive</a> resolve?\r\n\r\n###
         Functionality\r\n\r\n- [ ] **Installation:** Does installation proceed as
         outlined in the documentation?\r\n- [ ] **Functionality:** Have the functional
         claims of the software been confirmed?\r\n- [ ] **Performance:** Have the
@@ -155,7 +155,7 @@ http_interactions:
         author:** @harpolea (<a href=\"http://orcid.org/0000-0002-1530-781X\">Alice
         Harpole</a>)\r\n**Repository:** <a href=\"https://github.com/harpolea/r3d2\"
         target =\"_blank\">https://github.com/harpolea/r3d2</a>\r\n**Version:** v1.0\r\n**Archive:**
-        <a href=\"http://dx.doi.org/10.5281/zenodo.51096\" target =\"_blank\">http://dx.doi.org/10.5281/zenodo.51096</a>\r\n\r\n##
+        <a href=\"https://doi.org/10.5281/zenodo.51096\" target =\"_blank\">https://doi.org/10.5281/zenodo.51096</a>\r\n\r\n##
         Status\r\n\r\n[![status](http://joss.theoj.org/papers/99f57be50022ae8b2eecdd1d28b05766/status.svg)](http://joss.theoj.org/papers/99f57be50022ae8b2eecdd1d28b05766)\r\n\r\nStatus
         badge code:\r\n\r\n```\r\nHTML: <a href=\"http://joss.theoj.org/papers/99f57be50022ae8b2eecdd1d28b05766\"><img
         src=\"http://joss.theoj.org/papers/99f57be50022ae8b2eecdd1d28b05766/status.svg\"></a>\r\nMarkdown:
@@ -166,7 +166,7 @@ http_interactions:
         Does the repository contain a plain-text LICENSE file with the contents of
         an [OSI approved](https://opensource.org/licenses/alphabetical) software license?\r\n-
         [x] **Version:** Does the release version given match the GitHub release (v1.0)?\r\n-
-        [x] **Archive:** Does the <a target=\"_blank\" href=\"http://dx.doi.org/10.5281/zenodo.51096\">software
+        [x] **Archive:** Does the <a target=\"_blank\" href=\"https://doi.org/10.5281/zenodo.51096\">software
         archive</a> resolve?\r\n\r\n### Functionality\r\n\r\n- [ ] **Installation:**
         Does installation proceed as outlined in the documentation?\r\n- [ ] **Functionality:**
         Have the functional claims of the software been confirmed?\r\n- [ ] **Performance:**
@@ -193,8 +193,8 @@ http_interactions:
         author:** @jakevdp (<a href=\"http://orcid.org/0000-0002-9623-3401\">Jacob
         VanderPlas</a>)\r\n**Repository:** <a href=\"http://github.com/jakevdp/mst_clustering\"
         target=\"_blank\">http://github.com/jakevdp/mst_clustering</a>\r\n**Version:**
-        v1.0.0\r\n**Archive:** <a href=\"http://dx.doi.org/10.5281/zenodo.50995\"
-        target =\"_blank\">http://dx.doi.org/10.5281/zenodo.50995</a>\r\n\r\n## Status\r\n\r\n[![status](http://joss.theoj.org/papers/0b73d249cd34985b6fa1a5ad4f4f8014/status.svg)](http://joss.theoj.org/papers/0b73d249cd34985b6fa1a5ad4f4f8014)\r\n\r\nStatus
+        v1.0.0\r\n**Archive:** <a href=\"https://doi.org/10.5281/zenodo.50995\"
+        target =\"_blank\">https://doi.org/10.5281/zenodo.50995</a>\r\n\r\n## Status\r\n\r\n[![status](http://joss.theoj.org/papers/0b73d249cd34985b6fa1a5ad4f4f8014/status.svg)](http://joss.theoj.org/papers/0b73d249cd34985b6fa1a5ad4f4f8014)\r\n\r\nStatus
         badge code:\r\n\r\n```\r\nHTML: <a href=\"http://joss.theoj.org/papers/0b73d249cd34985b6fa1a5ad4f4f8014\"><img
         src=\"http://joss.theoj.org/papers/0b73d249cd34985b6fa1a5ad4f4f8014/status.svg\"></a>\r\nMarkdown:
         [![status](http://joss.theoj.org/papers/0b73d249cd34985b6fa1a5ad4f4f8014/status.svg)]http://joss.theoj.org/papers/0b73d249cd34985b6fa1a5ad4f4f8014\r\n```\r\n\r\n##
@@ -205,7 +205,7 @@ http_interactions:
         the contents of an [OSI approved](https://opensource.org/licenses/alphabetical)
         software license?\r\n- [ ] **Version:** Does the release version given match
         the GitHub release (v1.0.0)?\r\n- [x] **Archive:** Does the <a target=\"_blank\"
-        href=\"http://dx.doi.org/10.5281/zenodo.50995\">software archive</a> resolve?\r\n\r\n###
+        href=\"https://doi.org/10.5281/zenodo.50995\">software archive</a> resolve?\r\n\r\n###
         Functionality\r\n\r\n- [x] **Installation:** Does installation proceed as
         outlined in the documentation?\r\n- [x] **Functionality:** Have the functional
         claims of the software been confirmed?\r\n- [x] **Performance:** Have the
@@ -232,7 +232,7 @@ http_interactions:
         author:** @hrbrmstr (<a href=\"http://orcid.org/0000-0001-5670-2640\">Bob
         Rudis</a>)\r\n**Repository:** <a href=\"https://github.com/hrbrmstr/metricsgraphics\"
         target=\"_blank\">https://github.com/hrbrmstr/metricsgraphics</a>\r\n**Version:**
-        v0.9.1\r\n**Archive:** <a href=\"http://dx.doi.org/10.5281/zenodo.50373\"
+        v0.9.1\r\n**Archive:** <a href=\"https://doi.org/10.5281/zenodo.50373\"
         target=\"_blank\">10.5281/zenodo.50373</a>\r\n\r\n## Status\r\n\r\n[![status](http://joss.theoj.org/papers/1677676c38bd118db5fe363a6eb3f88f/status.svg)](http://joss.theoj.org/papers/1677676c38bd118db5fe363a6eb3f88f)\r\n\r\nStatus
         badge code:\r\n\r\n```\r\nHTML: <a href=\"http://joss.theoj.org/papers/1677676c38bd118db5fe363a6eb3f88f\"><img
         src=\"http://joss.theoj.org/papers/1677676c38bd118db5fe363a6eb3f88f/status.svg\"></a>\r\nMarkdown:

--- a/resources/html.template
+++ b/resources/html.template
@@ -26,7 +26,7 @@ $google_authors$
     </div>
 
     <div class="one-third column" style="padding-top: 20px;">
-      <span class="repo">DOI:<br /><a href="http://dx.doi.org/$formatted_doi$">http://dx.doi.org/$formatted_doi$</a></span>
+      <span class="repo">DOI:<br /><a href="https://doi.org/$formatted_doi$">https://doi.org/$formatted_doi$</a></span>
     </div>
     <div class="one-third column" style="padding-top: 20px;">
       <span class="paper">Status badge:<br /><img src="http://joss.theoj.org/papers/$formatted_doi$/status.svg"></span>

--- a/resources/latex.template
+++ b/resources/latex.template
@@ -225,7 +225,7 @@ $abstract$
 \end{abstract}
 $endif$
 
-\textbf{Paper DOI:} \url{http://dx.doi.org/$formatted_doi$}\\
+\textbf{Paper DOI:} \url{https://doi.org/$formatted_doi$}\\
 \textbf{Software Repository:} \url{$repository$}\\
 \textbf{Software Archive:} \url{$archive_doi$}\\
 

--- a/spec/auditor_spec.rb
+++ b/spec/auditor_spec.rb
@@ -17,6 +17,6 @@ describe Whedon::Auditor do
   end
 
   it "knows how to find the archive from the issue body" do
-    expect(subject.verify_archive).to eql("Archive: \"http://dx.doi.org/10.5281/zenodo.13750\"")
+    expect(subject.verify_archive).to eql("Archive: \"https://doi.org/10.5281/zenodo.13750\"")
   end
 end


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates static DOI links and the code that generates new ones.

Cheers!