### PR TITLE
Custom reviewer responder

### DIFF
--- a/app/lib/actions.rb
+++ b/app/lib/actions.rb
@@ -7,24 +7,24 @@ module Actions
 
   # Update the body of the issue between marks
   def update_body(start_mark, end_mark, new_text)
-    new_body = issue_body.gsub(/#{start_mark}.*#{end_mark}/im, "#{start_mark}#{new_text}#{end_mark}")
-    update_issue({ body: new_body })
+    @issue_body = issue_body.gsub(/#{start_mark}.*#{end_mark}/im, "#{start_mark}#{new_text}#{end_mark}")
+    update_issue({ body: @issue_body })
   end
 
   # Add text at the end of the body of the issue
   def append_to_body(text)
-    new_body = issue_body + text
-    update_issue({ body: new_body })
+    @issue_body = issue_body + text
+    update_issue({ body: @issue_body })
   end
 
   # Remove a block of text from the body of the issue optionally including start/end marks
   def delete_from_body(start_mark, end_mark, delete_marks=false)
     if delete_marks
-      new_body = issue_body.gsub(/#{start_mark}.*#{end_mark}/im, "")
+      @issue_body = issue_body.gsub(/#{start_mark}.*#{end_mark}/im, "")
     else
-      new_body = issue_body.gsub(/#{start_mark}.*#{end_mark}/im, "#{start_mark}#{end_mark}")
+      @issue_body = issue_body.gsub(/#{start_mark}.*#{end_mark}/im, "#{start_mark}#{end_mark}")
     end
-    update_issue({ body: new_body })
+    update_issue({ body: @issue_body })
   end
 
   # Invite a user to collaborate in the repo
@@ -83,9 +83,7 @@ module Actions
 
   # Update list in issue's body between HTML comments
   def update_list(list_name, text)
-    start_mark = "<!--#{list_name}-list-->"
-    end_mark = "<!--end-#{list_name}-list-->"
-    update_body(start_mark, end_mark, text)
+    update_value("#{list_name}-list", text)
   end
 
   # Replace an assigned user from the assignees list of the issue

--- a/app/lib/github.rb
+++ b/app/lib/github.rb
@@ -22,7 +22,7 @@ module GitHub
 
   # Return the body of issue
   def issue_body
-    @issue_body = context.issue_body
+    @issue_body ||= context.issue_body
     @issue_body ||= issue.body
   end
 

--- a/app/lib/responder.rb
+++ b/app/lib/responder.rb
@@ -21,6 +21,14 @@ class Responder
   attr_accessor :match_data
   attr_accessor :context
 
+  def self.keyname(key)
+    @key = key.to_s
+  end
+
+  def self.key
+    @key || self.name
+  end
+
 
   def initialize(settings, params)
     settings[:env] = default_settings.merge(settings[:env] || {})

--- a/app/responders/add_and_remove_assignee_responder.rb
+++ b/app/responders/add_and_remove_assignee_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class AddAndRemoveAssigneeResponder < Responder
 
+  keyname :add_remove_assignee
+
   def define_listening
     @event_action = "issue_comment.created"
     @event_regex = /\A@#{@bot_name} (add|remove) assignee: (\S+)\s*\z/i

--- a/app/responders/add_and_remove_user_checklist_responder.rb
+++ b/app/responders/add_and_remove_user_checklist_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class AddAndRemoveUserChecklistResponder < Responder
 
+  keyname :add_remove_checklist
+
   def define_listening
     required_params :template_file
 

--- a/app/responders/assign_editor_responder.rb
+++ b/app/responders/assign_editor_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class AssignEditorResponder < Responder
 
+  keyname :assign_editor
+
   def define_listening
     @event_action = "issue_comment.created"
     @event_regex = /\A@#{@bot_name} assign (\S+) as editor\s*\z/i

--- a/app/responders/assign_reviewer_n_responder.rb
+++ b/app/responders/assign_reviewer_n_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class AssignReviewerNResponder < Responder
 
+  keyname :assign_reviewer_n
+
   def define_listening
     @event_action = "issue_comment.created"
     @event_regex = /\A@#{@bot_name} assign (\S+) as reviewer (\S+)\s*\z/i

--- a/app/responders/basic_command_responder.rb
+++ b/app/responders/basic_command_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class BasicCommandResponder < Responder
 
+  keyname :basic_command
+
   def define_listening
     required_params :command
 

--- a/app/responders/check_references_responder.rb
+++ b/app/responders/check_references_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class CheckReferencesResponder < Responder
 
+  keyname :check_references
+
   def define_listening
     @event_action = "issue_comment.created"
     @event_regex = /\A@#{@bot_name} check references(?: from branch ([\w-]+))?\s*\z/i

--- a/app/responders/close_issue_command_responder.rb
+++ b/app/responders/close_issue_command_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class CloseIssueCommandResponder < Responder
 
+  keyname :close_issue_command
+
   def define_listening
     required_params :command
 

--- a/app/responders/external_service_responder.rb
+++ b/app/responders/external_service_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class ExternalServiceResponder < Responder
 
+  keyname :external_service
+
   def define_listening
     required_params :name, :command, :url
 

--- a/app/responders/hello_responder.rb
+++ b/app/responders/hello_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class HelloResponder < Responder
 
+  keyname :hello
+
   def define_listening
     @event_action = "issue_comment.created"
     @event_regex = /\A(Hello|Hi) @#{@bot_name}\s*\z/i

--- a/app/responders/help_responder.rb
+++ b/app/responders/help_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class HelpResponder < Responder
 
+  keyname :help
+
   def define_listening
     @event_action = "issue_comment.created"
     @event_regex = /\A@#{@bot_name} #{help_command}\s*\z/i

--- a/app/responders/invite_responder.rb
+++ b/app/responders/invite_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class InviteResponder < Responder
 
+  keyname :invite
+
   def define_listening
     @event_action = "issue_comment.created"
     @event_regex = /\A@#{@bot_name} invite (\S+)\s*\z/i

--- a/app/responders/label_command_responder.rb
+++ b/app/responders/label_command_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class LabelCommandResponder < Responder
 
+  keyname :label_command
+
   def define_listening
     required_params :command
     check_labels_present

--- a/app/responders/list_of_values_responder.rb
+++ b/app/responders/list_of_values_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class ListOfValuesResponder < Responder
 
+  keyname :list_of_values
+
   def define_listening
     required_params :name
 

--- a/app/responders/remove_editor_responder.rb
+++ b/app/responders/remove_editor_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class RemoveEditorResponder < Responder
 
+  keyname :remove_editor
+
   def define_listening
     @event_action = "issue_comment.created"
     @event_regex = /\A@#{@bot_name} remove editor\s*\z/i

--- a/app/responders/remove_reviewer_n_responder.rb
+++ b/app/responders/remove_reviewer_n_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class RemoveReviewerNResponder < Responder
 
+  keyname :remove_reviewer_n
+
   def define_listening
     @event_action = "issue_comment.created"
     @event_regex = /\A@#{@bot_name} remove reviewer (\S+)\s*\z/i

--- a/app/responders/repo_checks_responder.rb
+++ b/app/responders/repo_checks_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class RepoChecksResponder < Responder
 
+  keyname :repo_checks
+
   def define_listening
     @event_action = "issue_comment.created"
     @event_regex = /\A@#{@bot_name} check repository(?: from branch ([\w-]+))?\s*\z/i

--- a/app/responders/ropensci/reviewers_due_date_responder.rb
+++ b/app/responders/ropensci/reviewers_due_date_responder.rb
@@ -1,0 +1,81 @@
+require_relative '../../lib/responder'
+
+class ReviewersDueDateResponder < Responder
+
+  def define_listening
+    @event_action = "issue_comment.created"
+    @event_regex = /\A@#{@bot_name} (add|remove) (\S+) (as reviewer|to reviewers|from reviewers)\s*\z/i
+  end
+
+  def process_message(message)
+    add_or_remove = @match_data[1].downcase
+    reviewer = @match_data[2]
+    to_or_from = @match_data[3].downcase
+
+    if !issue_body_has?("reviewers-list")
+      respond("I can't find the reviewers list")
+      return
+    end
+
+    add_to_or_remove_from = [add_or_remove, to_or_from].join(" ")
+
+    if ["add to reviewers", "add as reviewer"].include?(add_to_or_remove_from)
+      add reviewer
+    elsif add_to_or_remove_from == "remove from reviewers"
+      remove reviewer
+    else
+      respond("That command is confusing. Did you mean to ADD TO reviewers or to REMOVE FROM reviewers?")
+    end
+  end
+
+  def add(reviewer)
+    if list_of_values.include?(reviewer)
+      respond("#{reviewer} is already included in the reviewers list")
+    else
+      new_list = (list_of_values + [reviewer]).uniq.join(", ")
+      update_list("reviewers", new_list)
+      respond("#{reviewer} added to the reviewers list!")
+      add_collaborator(reviewer) if add_as_collaborator?(reviewer)
+      add_assignee(reviewer) if add_as_assignee?(reviewer)
+      process_labeling if list_of_values.empty?
+    end
+  end
+
+  def remove(reviewer)
+    if list_of_values.include?(reviewer)
+      new_list = (list_of_values - [reviewer]).uniq.join(", ")
+      update_list("reviewers", new_list)
+      respond("#{reviewer} removed from the reviewers list!")
+      remove_assignee(reviewer) if add_as_assignee?(reviewer)
+      process_reverse_labeling if new_list.empty?
+    else
+      respond("#{reviewer} is not in the reviewers list")
+    end
+  end
+
+  def list_of_values
+    @list_of_values ||= read_value_from_body("reviewers-list").split(",").map(&:strip)-[no_reviewer_text]
+  end
+
+  def no_reviewer_text
+    params[:no_reviewer_text] || 'TBD'
+  end
+
+  def add_as_collaborator?(value)
+    username?(value) && params[:add_as_collaborator] == true
+  end
+
+  def add_as_assignee?(value)
+    username?(value) && params[:add_as_assignee] == true
+  end
+
+  def description
+    ["Add a user to this issue's reviewers list",
+     "Remove a user from the reviewers list"]
+  end
+
+  def example_invocation
+    ["@#{@bot_name} add #{params[:sample_value] || 'xxxxx'} to reviewers",
+     "@#{@bot_name} remove #{params[:sample_value] || 'xxxxx'} from reviewers"]
+  end
+end

--- a/app/responders/ropensci/reviewers_due_date_responder.rb
+++ b/app/responders/ropensci/reviewers_due_date_responder.rb
@@ -35,22 +35,23 @@ module Ropensci
       if list_of_values.include?(reviewer)
         respond("#{reviewer} is already included in the reviewers list")
       else
-        new_list = (list_of_values + [reviewer]).uniq.join(", ")
-        update_list("reviewers", new_list)
+        new_list = (list_of_values + [reviewer]).uniq
+        update_list("reviewers", new_list.join(", "))
         respond("#{reviewer} added to the reviewers list!")
         add_collaborator(reviewer) if add_as_collaborator?(reviewer)
         add_assignee(reviewer) if add_as_assignee?(reviewer)
-        process_labeling if list_of_values.empty?
+        process_labeling if new_list.size == 2
       end
     end
 
     def remove(reviewer)
       if list_of_values.include?(reviewer)
-        new_list = (list_of_values - [reviewer]).uniq.join(", ")
-        update_list("reviewers", new_list)
+        new_list = (list_of_values - [reviewer]).uniq
+        updated_list = new_list.empty? ? no_reviewer_text : new_list.join(", ")
+        update_list("reviewers", updated_list)
         respond("#{reviewer} removed from the reviewers list!")
         remove_assignee(reviewer) if add_as_assignee?(reviewer)
-        process_reverse_labeling if new_list.empty?
+        process_reverse_labeling if new_list.size == 1
       else
         respond("#{reviewer} is not in the reviewers list")
       end

--- a/app/responders/set_value_responder.rb
+++ b/app/responders/set_value_responder.rb
@@ -2,6 +2,8 @@ require_relative "../lib/responder"
 
 class SetValueResponder < Responder
 
+  keyname :set_value
+
   def define_listening
     required_params :name
 

--- a/app/responders/thanks_responder.rb
+++ b/app/responders/thanks_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class ThanksResponder < Responder
 
+  keyname :thanks
+
   def define_listening
     @event_action = "issue_comment.created"
     @event_regex = /\A(@#{@bot_name} thanks|@#{@bot_name} thank you|thanks @#{@bot_name}|thank you @#{@bot_name})/i

--- a/app/responders/welcome_responder.rb
+++ b/app/responders/welcome_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class WelcomeResponder < Responder
 
+  keyname :welcome
+
   def define_listening
     @event_action = "issues.opened"
     @event_regex = nil

--- a/app/responders/welcome_template_responder.rb
+++ b/app/responders/welcome_template_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class WelcomeTemplateResponder < Responder
 
+  keyname :welcome_template
+
   def define_listening
     required_params :template_file
 

--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -27,7 +27,7 @@ buffy:
             - 1/editor-checks
           add_labels:
             - 2/seeking-reviewer(s)
-          only: 
+          only:
             - editors
             - maelle
       - approved:
@@ -38,43 +38,39 @@ buffy:
             - reviewer-1
             - reviewer-2
           remove_labels:
-            - 5/awaiting-reviewer(s)-response 
+            - 5/awaiting-reviewer(s)-response
           add_labels:
-            - 6/approved 
-          only: 
+            - 6/approved
+          only:
             - editors
             - maelle
-    assign_reviewer_n:
-      only: 
+    ropensci_reviewers:
+      only:
         - editors
         - maelle
       if:
         role_assigned: editor
-    remove_reviewer_n:
-      only: 
-        - editors
-        - maelle
       no_reviewer_text: "TBD"
     assign_editor:
       message: "The editor guide can be found at https://devguide.ropensci.org/editorguide.html#editorchecklist"
-      only: 
+      only:
         - editors
         - maelle
       add_labels:
         - 1/editor-checks
     remove_editor:
-      only: 
+      only:
         - editors
         - maelle
       no_editor_text: "TBD"
     close_issue_command:
       - when_approving:
-          only: 
+          only:
             - editors
             - maelle
           command: approve
       - out_of_scope:
-          only: 
+          only:
             - editors
             - maelle
           command: out of scope
@@ -82,4 +78,4 @@ buffy:
             - out-of-scope
           remove_labels:
             - 1/editor-checks
-      
+

--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -51,6 +51,10 @@ buffy:
       if:
         role_assigned: editor
       no_reviewer_text: "TBD"
+      add_labels:
+        - 3/reviewer(s)-assigned
+      remove_labels:
+        - 2/seeking-reviewer(s)
     assign_editor:
       message: "The editor guide can be found at https://devguide.ropensci.org/editorguide.html#editorchecklist"
       only:

--- a/spec/actions_spec.rb
+++ b/spec/actions_spec.rb
@@ -18,46 +18,65 @@ describe "Actions" do
   end
 
   describe "#update_body" do
+    before do
+      @initial_body = "... <before> Here! <after> ..."
+      @expected_new_body = "... <before> New content! <after> ..."
+      @context = OpenStruct.new(issue_body: @initial_body)
+
+      allow(subject).to receive(:context).and_return(@context)
+      expect(subject).to receive(:update_issue).once.with({body: @expected_new_body})
+
+    end
+
     it "should call update_issue on new body" do
-      issue_body = "... <before> Here! <after> ..."
-      allow(subject).to receive(:issue_body).and_return(issue_body)
-
-      expected_new_body = "... <before> New content! <after> ..."
-
-      expect(subject).to receive(:update_issue).once.with({body: expected_new_body})
       subject.update_body("<before>", "<after>" ," New content! ")
+    end
+
+    it "should update @body_issue" do
+      expect(subject.issue_body).to eq(@initial_body)
+      subject.update_body("<before>", "<after>" ," New content! ")
+      expect(subject.issue_body).to eq(@expected_new_body)
     end
   end
 
   describe "#append_to_body" do
+    before do
+      @initial_body = "Hi <before> there! <after> this is the end"
+      @context = OpenStruct.new(issue_body: @initial_body)
+      @expected_new_body = "Hi <before> there! <after> this is the end\nNow this is the new end"
+
+      allow(subject).to receive(:context).and_return(@context)
+      expect(subject).to receive(:update_issue).once.with({body: @expected_new_body})
+    end
+
     it "should call update_issue on new body" do
-      issue_body = "Hi <before> there! <after> this is the end"
-      allow(subject).to receive(:issue_body).and_return(issue_body)
-
-      expected_new_body = "Hi <before> there! <after> this is the end\nNow this is the new end"
-
-      expect(subject).to receive(:update_issue).once.with({body: expected_new_body})
       subject.append_to_body("\nNow this is the new end")
+    end
+
+    it "should update @body_issue" do
+      expect(subject.issue_body).to eq(@initial_body)
+      subject.append_to_body("\nNow this is the new end")
+      expect(subject.issue_body).to eq(@expected_new_body)
     end
   end
 
   describe "#delete_from_body" do
     before do
-      issue_body = "Intro <before> Here!\n <after> Final"
-      allow(subject).to receive(:issue_body).and_return(issue_body)
+      @initial_body = "Intro <before> Here!\n <after> Final"
+      @expected_new_body = "Intro <before><after> Final"
+      @context = OpenStruct.new(issue_body: @initial_body)
+      allow(subject).to receive(:context).and_return(@context)
     end
 
-    it "should not remove marks by default" do
-      expected_new_body = "Intro <before><after> Final"
-
-      expect(subject).to receive(:update_issue).once.with({body: expected_new_body})
+    it "should not remove marks by default and update @body_issue" do
+      expect(subject.issue_body).to eq(@initial_body)
+      expect(subject).to receive(:update_issue).once.with({body: @expected_new_body})
       subject.delete_from_body("<before>", "<after>")
+      expect(subject.issue_body).to eq(@expected_new_body)
     end
 
     it "should call update_issue on new body removing block content" do
-      expected_new_body = "Intro <before><after> Final"
-
-      expect(subject).to receive(:update_issue).once.with({body: expected_new_body})
+      expect(subject).to receive(:update_issue).once.with({body: @expected_new_body})
       subject.delete_from_body("<before>", "<after>", false)
     end
 

--- a/spec/responder_registry_spec.rb
+++ b/spec/responder_registry_spec.rb
@@ -15,6 +15,11 @@ describe ResponderRegistry do
   end
 
   describe "initialization" do
+    it "should load available responders mapping" do
+      registry = described_class.new(@config)
+      expect(registry.responders_map).to eq(ResponderRegistry.available_responders)
+    end
+
     it "should load single responders" do
       registry = described_class.new(@config)
       single_responder = registry.responders.select { |r| r.kind_of?(AssignReviewerNResponder) }
@@ -58,6 +63,17 @@ describe ResponderRegistry do
         expect(responder.teams[:editors]).to eq(expected_teams[:editors])
         expect(responder.teams[:eics]).to eq(expected_teams[:eics])
       end
+    end
+  end
+
+  describe ".available_responders" do
+    it "should return a map of all available responders" do
+      map = ResponderRegistry.available_responders
+      files_count = Dir["#{File.expand_path '../../app/responders', __FILE__}/**/*.rb"].length
+      expect(map.count).to eq(files_count)
+
+      random_responder_key = map.keys[(0..files_count-1).to_a.sample]
+      expect(map[random_responder_key].key).to eq(random_responder_key)
     end
   end
 

--- a/spec/responder_spec.rb
+++ b/spec/responder_spec.rb
@@ -259,9 +259,29 @@ describe Responder do
     end
   end
 
+  describe ".keyname" do
+    it "should be class name by default" do
+      expect(described_class.key).to eq("Responder")
+    end
+
+    it "should set the key name" do
+      described_class.keyname :buffy_tester
+      expect(described_class.key).to eq("buffy_tester")
+    end
+  end
+
+  describe "#key" do
+    it "should be present for all responders" do
+      ResponderRegistry.available_responders.values.each do |responder_class|
+        expect(responder_class.key).to_not be_nil
+        expect(responder_class.key).to_not eq(responder_class.name)
+      end
+    end
+  end
+
   describe "#description" do
     it "should be present for all responders" do
-      ResponderRegistry::RESPONDER_MAPPING.values.each do |responder_class|
+      ResponderRegistry.available_responders.values.each do |responder_class|
         responder = responder_class.new({}, sample_params(responder_class))
         expect(responder.respond_to?(:description)).to eq(true)
         expect(responder.description).to_not be_nil
@@ -272,7 +292,7 @@ describe Responder do
 
   describe "#example_invocation" do
     it "should be present for all responders" do
-      ResponderRegistry::RESPONDER_MAPPING.values.each do |responder_class|
+      ResponderRegistry.available_responders.values.each do |responder_class|
         responder = responder_class.new({}, sample_params(responder_class))
         expect(responder.respond_to?(:example_invocation)).to eq(true)
         expect(responder.example_invocation).to_not be_nil
@@ -283,7 +303,7 @@ describe Responder do
 
   describe "multiple descriptions and example invocations" do
     it "should have the same number of each of them" do
-      ResponderRegistry::RESPONDER_MAPPING.values.each do |responder_class|
+      ResponderRegistry.available_responders.values.each do |responder_class|
         responder = responder_class.new({}, sample_params(responder_class))
         if responder.description.is_a?(Array) || responder.example_invocation.is_a?(Array)
           error_msg = "#{responder_class.name} descriptions and example_invocations sizes don't match"

--- a/spec/responders/ropensci/reviewers_due_date_responder_spec.rb
+++ b/spec/responders/ropensci/reviewers_due_date_responder_spec.rb
@@ -116,6 +116,82 @@ describe Ropensci::ReviewersDueDateResponder do
         @responder.process_message(@msg)
       end
     end
+
+    describe "process labels" do
+      describe "adding labels" do
+        before do
+          @msg = "@ropensci-review-bot add @maelle to reviewers"
+          @responder.match_data = @responder.event_regex.match(@msg)
+        end
+
+        it "should not happen with less than two reviewers" do
+          issue_body = "...Reviewers: <!--reviewers-list--><!--end-reviewers-list--> ..."
+          allow(@responder).to receive(:issue_body).and_return(issue_body)
+
+          expect(@responder).to_not receive(:process_labeling)
+          expect(@responder).to_not receive(:process_reverse_labeling)
+
+          @responder.process_message(@msg)
+        end
+
+        it "should not happen with more than two reviewers" do
+          issue_body = "...Reviewers: <!--reviewers-list-->@karthik, @mpadge<!--end-reviewers-list--> ..."
+          allow(@responder).to receive(:issue_body).and_return(issue_body)
+
+          expect(@responder).to_not receive(:process_labeling)
+          expect(@responder).to_not receive(:process_reverse_labeling)
+
+          @responder.process_message(@msg)
+        end
+
+        it "should happen when the second reviewer is assigned" do
+          issue_body = "...Reviewers: <!--reviewers-list-->@karthik<!--end-reviewers-list--> ..."
+          allow(@responder).to receive(:issue_body).and_return(issue_body)
+
+          expect(@responder).to receive(:process_labeling)
+          expect(@responder).to_not receive(:process_reverse_labeling)
+
+          @responder.process_message(@msg)
+        end
+      end
+
+      describe "removing labels" do
+        before do
+          @msg = "@ropensci-review-bot remove @maelle from reviewers"
+          @responder.match_data = @responder.event_regex.match(@msg)
+        end
+
+        it "should not happen with less than two reviewers" do
+          issue_body = "...Reviewers: <!--reviewers-list-->@maelle<!--end-reviewers-list--> ..."
+          allow(@responder).to receive(:issue_body).and_return(issue_body)
+
+          expect(@responder).to_not receive(:process_reverse_labeling)
+          expect(@responder).to_not receive(:process_labeling)
+
+          @responder.process_message(@msg)
+        end
+
+        it "should not happen with more than two reviewers" do
+          issue_body = "...Reviewers: <!--reviewers-list-->@karthik, @mpadge, @maelle<!--end-reviewers-list--> ..."
+          allow(@responder).to receive(:issue_body).and_return(issue_body)
+
+          expect(@responder).to_not receive(:process_reverse_labeling)
+          expect(@responder).to_not receive(:process_labeling)
+
+          @responder.process_message(@msg)
+        end
+
+        it "should happen when the second reviewer is removed" do
+          issue_body = "...Reviewers: <!--reviewers-list-->@karthik, @maelle<!--end-reviewers-list--> ..."
+          allow(@responder).to receive(:issue_body).and_return(issue_body)
+
+          expect(@responder).to receive(:process_reverse_labeling)
+          expect(@responder).to_not receive(:process_labeling)
+
+          @responder.process_message(@msg)
+        end
+      end
+    end
   end
 
   describe "#add_as_collaborator?" do

--- a/spec/responders/ropensci/reviewers_due_date_responder_spec.rb
+++ b/spec/responders/ropensci/reviewers_due_date_responder_spec.rb
@@ -1,0 +1,181 @@
+require_relative "../../spec_helper.rb"
+
+describe ReviewersDueDateResponder do
+
+  subject do
+    described_class
+  end
+
+  before { @responder = subject.new({env: {bot_github_user: "ropensci-review-bot"}}, {}) }
+
+  describe "listening" do
+    it "should listen to new comments" do
+      expect(@responder.event_action).to eq("issue_comment.created")
+    end
+
+    it "should define regex" do
+      expect(@responder.event_regex).to match("@ropensci-review-bot add @maelle to reviewers")
+      expect(@responder.event_regex).to match("@ropensci-review-bot add @maelle as reviewer")
+      expect(@responder.event_regex).to match("@ropensci-review-bot remove @maelle from reviewers  \r\n")
+      expect(@responder.event_regex).to_not match("@ropensci-review-bot add to reviewers")
+      expect(@responder.event_regex).to_not match("@ropensci-review-bot add as reviewers")
+      expect(@responder.event_regex).to_not match("@ropensci-review-bot remove   from reviewers")
+    end
+  end
+
+  describe "#process_message" do
+    before do
+      disable_github_calls_for(@responder)
+    end
+
+    describe "adding to list" do
+      before do
+        @msg = "@ropensci-review-bot add @xuanxu to reviewers"
+        @responder.match_data = @responder.event_regex.match(@msg)
+
+        issue_body = "...Reviewers: <!--reviewers-list-->@maelle<!--end-reviewers-list--> ..."
+        allow(@responder).to receive(:issue_body).and_return(issue_body)
+      end
+
+      it "should add value to the list in the body of the issue" do
+        expected_new_body = "...Reviewers: <!--reviewers-list-->@maelle, @xuanxu<!--end-reviewers-list--> ..."
+        expect(@responder).to receive(:update_issue).with({ body: expected_new_body })
+        @responder.process_message(@msg)
+      end
+
+      it "should respond to github" do
+        expect(@responder).to receive(:respond).with("@xuanxu added to the reviewers list!")
+        @responder.process_message(@msg)
+      end
+
+      it "should not add value if already present in the list" do
+        msg = "@ropensci-review-bot add @maelle to reviewers"
+        @responder.match_data = @responder.event_regex.match(msg)
+        expect(@responder).to_not receive(:update_issue)
+        expect(@responder).to receive(:respond).with("@maelle is already included in the reviewers list")
+        @responder.process_message(msg)
+      end
+
+      it "should not add as assignee/collaborator if not configured" do
+        expect(@responder).to_not receive(:add_collaborator)
+        expect(@responder).to_not receive(:add_assignee)
+        @responder.process_message(@msg)
+      end
+
+      it "should add as collaborator if configured" do
+        @responder.params[:add_as_collaborator] = true
+        expect(@responder).to receive(:add_collaborator)
+        expect(@responder).to_not receive(:add_assignee)
+        @responder.process_message(@msg)
+      end
+
+      it "should add as assignee if configured" do
+        @responder.params[:add_as_assignee] = true
+        expect(@responder).to_not receive(:add_collaborator)
+        expect(@responder).to receive(:add_assignee)
+        @responder.process_message(@msg)
+      end
+    end
+
+    describe "removing from list" do
+      before do
+        @msg = "@ropensci-review-bot remove @maelle from reviewers"
+        @responder.match_data = @responder.event_regex.match(@msg)
+
+        issue_body = "...Reviewers: <!--reviewers-list-->@karthik, @maelle<!--end-reviewers-list--> ..."
+        allow(@responder).to receive(:issue_body).and_return(issue_body)
+      end
+
+      it "should remove value from the list in the body of the issue" do
+        expected_new_body = "...Reviewers: <!--reviewers-list-->@karthik<!--end-reviewers-list--> ..."
+        expect(@responder).to receive(:update_issue).with({ body: expected_new_body })
+        @responder.process_message(@msg)
+      end
+
+      it "should respond to github" do
+        expect(@responder).to receive(:respond).with("@maelle removed from the reviewers list!")
+        @responder.process_message(@msg)
+      end
+
+      it "should not remove value if not present in the list" do
+        msg = "@ropensci-review-bot remove @other_user from reviewers"
+        @responder.match_data = @responder.event_regex.match(msg)
+        expect(@responder).to_not receive(:update_issue)
+        expect(@responder).to receive(:respond).with("@other_user is not in the reviewers list")
+        @responder.process_message(msg)
+      end
+
+      it "should not remove as assignee if not configured" do
+        expect(@responder).to_not receive(:remove_assignee)
+        @responder.process_message(@msg)
+      end
+
+      it "should remove as assignee if configured" do
+        @responder.params[:add_as_assignee] = true
+        expect(@responder).to receive(:remove_assignee)
+        @responder.process_message(@msg)
+      end
+    end
+  end
+
+  describe "#add_as_collaborator?" do
+    it "is false if value is not a username" do
+      expect(@responder.username?("not username value")).to be_falsy
+      expect(@responder.add_as_collaborator?("not username value")).to be_falsy
+    end
+
+    it "is false if param[:add_as_collaborator] is false" do
+      expect(@responder.username?("@username")).to be_truthy
+      expect(@responder.params[:add_as_collaborator]).to be_falsy
+      expect(@responder.add_as_collaborator?("@username")).to be_falsy
+    end
+
+    it "is true if value is username and param[:add_as_collaborator] is true" do
+      expect(@responder.username?("@username")).to be_truthy
+      @responder.params[:add_as_collaborator] = true
+      expect(@responder.add_as_collaborator?("@username")).to be_truthy
+    end
+  end
+
+  describe "#add_as_assignee?" do
+    it "is false if value is not a username" do
+      expect(@responder.username?("not username value")).to be_falsy
+      expect(@responder.add_as_assignee?("not username value")).to be_falsy
+    end
+
+    it "is false if param[:add_as_assignee] is false" do
+      expect(@responder.username?("@username")).to be_truthy
+      expect(@responder.params[:add_as_assignee]).to be_falsy
+      expect(@responder.add_as_assignee?("@username")).to be_falsy
+    end
+
+    it "is true if value is username and param[:add_as_assignee] is true" do
+      expect(@responder.username?("@username")).to be_truthy
+      @responder.params[:add_as_assignee] = true
+      expect(@responder.add_as_assignee?("@username")).to be_truthy
+    end
+  end
+
+  describe "documentation" do
+    before do
+      @responder.params = { sample_value: "@reviewer_username" }
+    end
+
+    it "#description should include name" do
+      expect(@responder.description[0]).to eq("Add a user to this issue's reviewers list")
+      expect(@responder.description[1]).to eq("Remove a user from the reviewers list")
+    end
+
+    it "#example_invocation should use custom sample value if present" do
+      expect(@responder.example_invocation[0]).to eq("@ropensci-review-bot add @reviewer_username to reviewers")
+      expect(@responder.example_invocation[1]).to eq("@ropensci-review-bot remove @reviewer_username from reviewers")
+    end
+
+    it "#example_invocation should have default sample value" do
+      @responder.params = {}
+      expect(@responder.example_invocation[0]).to eq("@ropensci-review-bot add xxxxx to reviewers")
+      expect(@responder.example_invocation[1]).to eq("@ropensci-review-bot remove xxxxx from reviewers")
+    end
+  end
+
+end

--- a/spec/responders/ropensci/reviewers_due_date_responder_spec.rb
+++ b/spec/responders/ropensci/reviewers_due_date_responder_spec.rb
@@ -1,6 +1,6 @@
 require_relative "../../spec_helper.rb"
 
-describe ReviewersDueDateResponder do
+describe Ropensci::ReviewersDueDateResponder do
 
   subject do
     described_class


### PR DESCRIPTION
This PR adds a custom responder to assign/remove reviewers adding a due date of 3 weeks after assignment to each one and labeling the issue once two reviewers are assigned.

Closes #3 

Note: For the responder to work, the body of the issues must have html placeholders for `reviewers` and `due-dates` lists.
[This other PR](https://github.com/ropenscilabs/review-robot-test/pull/9) adds them in the testing repository.